### PR TITLE
Fix "Save as Image" in Hyper Space

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -71,9 +71,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set Up Graal ${{ matrix.jdk-version }}
-        uses: graalvm/setup-graalvm@v1
+        uses: graalvm/setup-graalvm@v1.0.12
         with:
-          version: 'latest'
+          version: '22.3.2'
           java-version: ${{ matrix.jdk-version }}
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/main/java/edu/jhuapl/trinity/javafx/components/radial/HyperspaceMenu.java
+++ b/src/main/java/edu/jhuapl/trinity/javafx/components/radial/HyperspaceMenu.java
@@ -36,6 +36,7 @@ import lit.litfx.controls.menus.LitRadialMenuItem;
 import javax.imageio.ImageIO;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 
 /*-
  * #%L
@@ -328,10 +329,14 @@ public class HyperspaceMenu extends RadialEntity {
         addMenuItem(new LitRadialMenuItem(ITEM_SIZE * 0.5, "Save as Image", save, e -> {
             final FileChooser fileChooser = new FileChooser();
             fileChooser.setTitle("Save scene as...");
+            fileChooser.setInitialFileName("trinity_hyperspace.png");
+            fileChooser.setInitialDirectory(Paths.get(".").toFile());
             fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("PNG", "*.png"));
             File file = fileChooser.showSaveDialog(null);
             if (file != null) {
-                WritableImage image = this.snapshot(new SnapshotParameters(), null);
+                setVisible(false);
+                WritableImage image = hyperspace3DPane.snapshot(new SnapshotParameters(), null);
+                setVisible(true);
                 try {
                     ImageIO.write(SwingFXUtils.fromFXImage(image, null), "png", file);
                 } catch (IOException ioe) {

--- a/src/main/java/edu/jhuapl/trinity/javafx/javafx3d/Hypersurface3DPane.java
+++ b/src/main/java/edu/jhuapl/trinity/javafx/javafx3d/Hypersurface3DPane.java
@@ -117,6 +117,7 @@ import org.fxyz3d.utils.CameraTransformer;
 import javax.imageio.ImageIO;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -530,6 +531,8 @@ public class Hypersurface3DPane extends StackPane
         saveSnapshotItem.setOnAction((ActionEvent e) -> {
             final FileChooser fileChooser = new FileChooser();
             fileChooser.setTitle("Save scene as...");
+            fileChooser.setInitialFileName("trinity_hypersurface.png");
+            fileChooser.setInitialDirectory(Paths.get(".").toFile());
             fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("PNG", "*.png"));
             File file = fileChooser.showSaveDialog(null);
             if (file != null) {


### PR DESCRIPTION
fix: ensure the right node is used when a snapshot is taken on the hyperspace menu

chore: adding some sane defaults to FileChooser

Closes #18 